### PR TITLE
Per-monkey search UI + Preview tab config + on-demand wasm-pack

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "monkeynumber",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 8787
+    }
+  ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-bindgen = "0.2"
 
+# wasm-pack runs `wasm-opt`, which already strips and size-optimizes the binary
+# (~14 KB). Rust's `strip = true` is redundant here and makes wasm-opt fail, so
+# it's intentionally omitted.
 [profile.release]
 opt-level = 3
 lto = true

--- a/README.md
+++ b/README.md
@@ -65,13 +65,16 @@ command installs it** (via rustup) before `wrangler deploy` compiles the WASM.
    *Connect to Git* → pick this repo. Set the production branch to `main`. (Create a
    **Worker**, not a Pages project — the wrangler-config "Skipping file" warning in the
    build log is expected and harmless for a Workers build.)
-2. **Build command** — installs the toolchain the image lacks. Each step must be on the
+2. **Build command** — installs Rust, which the image lacks. Each step must be on the
    same line as the rest (the `. "$HOME/.cargo/env"` is required, or the next command
    fails with `cargo: not found`):
 
    ```shell
-   curl https://sh.rustup.rs -sSf | sh -s -- -y && . "$HOME/.cargo/env" && rustup target add wasm32-unknown-unknown && cargo install wasm-pack
+   curl https://sh.rustup.rs -sSf | sh -s -- -y && . "$HOME/.cargo/env" && rustup target add wasm32-unknown-unknown
    ```
+
+   No need to install wasm-pack here — the `build.command` hook in `wrangler.jsonc`
+   installs it on demand (`cargo install -q wasm-pack`) if it's missing.
 
 3. **Deploy command** — re-source cargo (separate shell), then deploy:
 
@@ -79,9 +82,9 @@ command installs it** (via rustup) before `wrangler deploy` compiles the WASM.
    . "$HOME/.cargo/env" && npx wrangler deploy
    ```
 
-   `wrangler deploy` runs the `build.command` hook in `wrangler.jsonc`, which builds
-   the WASM into `public/pkg/`, then uploads `public/` as static assets. (Don't put
-   `wasm-pack build` in the build command — the deploy step builds it.)
+   `wrangler deploy` runs the `build.command` hook in `wrangler.jsonc`, which installs
+   wasm-pack (if absent), builds the WASM into `public/pkg/`, then uploads `public/` as
+   static assets.
 4. **Stop the old Pages deploy** — remove the `monkeynumber.xyz` custom domain from the
    old Cloudflare Pages project and disable its automatic deployments (or delete it).
 5. **Move the domain to the Worker** — the `monkeynumber` Worker → Settings →
@@ -98,7 +101,7 @@ in the Workers Builds settings and every PR / non-`main` branch gets a
 
 ### Manual deploy (optional)
 
-With Rust + wasm-pack installed locally:
+With Rust installed locally (the build hook adds wasm-pack if it's missing):
 
 ```shell
 npm run deploy     # = wrangler deploy (builds the WASM via the wrangler build hook)

--- a/public/app.js
+++ b/public/app.js
@@ -1,14 +1,16 @@
-// Main thread: collect the target word, fan the search out across one WASM
-// worker per CPU core, and render the winning seed as a runnable Ruby command.
+// Main thread: collect the target word, fan the search out across one WASM worker
+// per CPU core, render one monkey per worker showing how close it has gotten to
+// the target, and show the winning seed as a runnable Ruby command.
 
 const form = document.getElementById('word-input-form');
 const input = document.getElementById('target-word-input');
+const idleMonkey = document.getElementById('idle-monkey');
+const monkeysEl = document.getElementById('monkeys');
 const resultRow = document.getElementById('monkey-result-row');
 const result = document.getElementById('monkey-result');
 const status = document.getElementById('monkey-status');
-const monkeys = document.querySelectorAll('.typewriter-monkey');
 
-// "abc" -> [0, 1, 2]; non-lowercase-letters are dropped, matching the original.
+// "abc" -> [0, 1, 2]; non-lowercase letters are dropped, matching the original.
 function stringToIndexArray(string) {
   return Array.from(string.toLowerCase())
     .filter((ch) => ch >= 'a' && ch <= 'z')
@@ -19,19 +21,46 @@ function displayAnswer(seed, length) {
   return `ruby -e "srand(${seed});puts ${length}.times.map{rand(97..123).chr}.join"`;
 }
 
-function startAnimation() {
-  monkeys.forEach((m) => m.classList.add('animated'));
-}
-
-function stopAnimation() {
-  setTimeout(() => monkeys.forEach((m) => m.classList.remove('animated')), 1000);
-}
+const formatCount = (n) => n.toLocaleString();
 
 let workers = [];
-
 function stopWorkers() {
   workers.forEach((w) => w.terminate());
   workers = [];
+}
+
+// One monkey card per worker; returns handles for live updates.
+function buildMonkeys(count, word) {
+  monkeysEl.textContent = '';
+  const cards = [];
+  for (let i = 0; i < count; i++) {
+    const card = document.createElement('div');
+    card.className = 'monkey-card';
+
+    const sprite = document.createElement('div');
+    sprite.className = 'typewriter-monkey mini-monkey animated';
+
+    const best = document.createElement('div');
+    best.className = 'monkey-best';
+    const hit = document.createElement('span');
+    hit.className = 'hit';
+    const miss = document.createElement('span');
+    miss.className = 'miss';
+    miss.textContent = word; // the goal, faded; fills in as the monkey matches
+    best.append(hit, miss);
+
+    card.append(sprite, best);
+    monkeysEl.append(card);
+    cards.push({ card, sprite, hit, miss, best: 0 });
+  }
+  return cards;
+}
+
+// Show that this monkey has reproduced the first `len` letters of `word`.
+function setClosest(card, word, len) {
+  card.best = len;
+  card.hit.textContent = word.slice(0, len);
+  card.miss.textContent = word.slice(len);
 }
 
 form.addEventListener('submit', (event) => {
@@ -40,39 +69,49 @@ form.addEventListener('submit', (event) => {
   const indices = stringToIndexArray(input.value);
   if (indices.length === 0) return; // nothing to search for
   const targetArray = Uint8Array.from(indices);
+  const word = indices.map((i) => String.fromCharCode(97 + i)).join('');
 
   stopWorkers();
   form.hidden = true;
+  idleMonkey.classList.add('hidden');
   resultRow.classList.add('hidden');
-  startAnimation();
 
   const numWorkers = navigator.hardwareConcurrency || 4;
+  const cards = buildMonkeys(numWorkers, word);
+  monkeysEl.classList.remove('hidden');
+
   let tried = 0;
   let done = false;
-
-  const formatCount = (n) => n.toLocaleString();
-  if (status) status.textContent = 'Searching…';
+  status.textContent = `Searching with ${numWorkers} monkeys…`;
 
   for (let i = 0; i < numWorkers; i++) {
+    const card = cards[i];
     const worker = new Worker(new URL('./monkey.worker.js', import.meta.url), {
       type: 'module',
     });
 
     worker.onmessage = (e) => {
-      if (done) return;
+      if (done && e.data.type !== 'completed') return;
       switch (e.data.type) {
-        case 'completed':
+        case 'completed': {
+          if (done) break;
           done = true;
           stopWorkers();
+          setClosest(card, word, word.length); // winner reached the full word
+          card.card.classList.add('winner');
           result.textContent = displayAnswer(e.data.seed, targetArray.length);
           resultRow.classList.remove('hidden');
-          if (status) status.textContent = `Found it — monkey number ${formatCount(e.data.seed)}.`;
-          stopAnimation();
+          status.textContent = `Found it — monkey number ${formatCount(e.data.seed)}.`;
+          // Let the winner take a victory lap, then settle every monkey.
+          setTimeout(() => cards.forEach((c) => c.sprite.classList.remove('animated')), 1200);
           break;
-        case 'progress':
+        }
+        case 'progress': {
           tried += e.data.tried;
-          if (status) status.textContent = `Searching… ${formatCount(tried)} seeds tried`;
+          if (e.data.best > card.best) setClosest(card, word, e.data.best);
+          status.textContent = `Searching… ${formatCount(tried)} seeds tried`;
           break;
+        }
         default:
           break;
       }

--- a/public/index.html
+++ b/public/index.html
@@ -25,10 +25,13 @@
   </nav>
 
   <main class="container">
-    <div class="monkey-row">
+    <div class="monkey-row" id="idle-monkey">
       <div class="typewriter-monkey large-monkey"></div>
       <div class="typewriter-monkey small-monkey"></div>
     </div>
+
+    <!-- One monkey per running worker, populated by app.js on submit. -->
+    <div id="monkeys" class="monkeys hidden" aria-live="polite"></div>
 
     <form id="word-input-form" class="input-row">
       <input id="target-word-input" type="text" autocomplete="off" autocapitalize="off"

--- a/public/monkey.worker.js
+++ b/public/monkey.worker.js
@@ -5,9 +5,10 @@ import init, { search } from './pkg/monkeynumber.js';
 
 const ready = init();
 
-// Seeds scanned per WASM call. Large enough to amortise the call overhead,
-// small enough to report progress and let the winner stop its siblings quickly.
-const BATCH = 1_000_000;
+// Seeds scanned per WASM call. Large enough to amortise the call overhead, small
+// enough that each monkey reports its "closest" often so progress is visible live
+// (and the winner stops its siblings quickly).
+const BATCH = 100_000;
 const U32 = 0x1_0000_0000; // 2^32
 
 self.onmessage = async (e) => {
@@ -17,20 +18,23 @@ self.onmessage = async (e) => {
   const target = new Uint8Array(targetArray);
   let seed = start >>> 0;
   let tried = 0;
+  let best = 0; // longest target prefix this monkey has reproduced so far
   // This worker is responsible for ~2^32 / stride seeds; stop once swept.
   const sliceSize = Math.ceil(U32 / stride);
 
   while (tried < sliceSize) {
-    const found = search(target, seed, stride, BATCH);
-    if (found !== undefined) {
-      self.postMessage({ type: 'completed', seed: found });
+    // [found, foundSeed, bestLen] for this batch.
+    const [found, foundSeed, bestLen] = search(target, seed, stride, BATCH);
+    if (found === 1) {
+      self.postMessage({ type: 'completed', seed: foundSeed });
       return;
     }
+    if (bestLen > best) best = bestLen;
     tried += BATCH;
     seed = (seed + stride * BATCH) >>> 0;
-    self.postMessage({ type: 'progress', tried: BATCH });
+    self.postMessage({ type: 'progress', tried: BATCH, best });
   }
 
   // Swept the whole slice without a hit (only happens for very long words).
-  self.postMessage({ type: 'exhausted' });
+  self.postMessage({ type: 'exhausted', best });
 };

--- a/public/style.css
+++ b/public/style.css
@@ -69,6 +69,33 @@ html, body {
 }
 .input-row button:hover { background: #e8e8e8; }
 
+/* Grid of working monkeys — one per running worker. */
+.monkeys {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 0.25rem 0.75rem;
+  min-height: 160px;
+}
+.monkey-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 120px;
+}
+.monkey-best {
+  margin-top: -1.25rem; /* tuck the label under the monkey's typewriter */
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  min-height: 1.2em;
+  word-break: break-all;
+}
+.monkey-best .hit { color: var(--fg); font-weight: 700; }
+.monkey-best .miss { color: var(--border); }
+.monkey-card.winner .monkey-best .hit { color: #2e7d32; }
+
 .status {
   color: var(--muted);
   min-height: 1.25rem;
@@ -117,6 +144,20 @@ html, body {
 }
 @keyframes play-large {
   100% { background-position: -8192px; }
+}
+
+/* Mini monkey: one per worker in the grid (16 frames × 120px). */
+.typewriter-monkey.mini-monkey {
+  width: 120px;
+  height: 120px;
+  background: url('/assets/typewriter-sprite.png') left center;
+  background-size: auto 120px;
+}
+.typewriter-monkey.mini-monkey.animated {
+  animation: play-mini 1s steps(16) infinite;
+}
+@keyframes play-mini {
+  100% { background-position: -1920px; }
 }
 
 /* Show the large monkey on wide screens, the small one on phones. */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,35 +99,50 @@ impl Default for Mt19937 {
     }
 }
 
-/// Does the MT stream seeded by `seed` begin with exactly `target`?
+/// Number of leading letters of `target` reproduced by the MT stream seeded by
+/// `seed`, stopping at the first mismatch. Equals `target.len()` exactly when the
+/// seed is a full match — and otherwise measures how "close" that seed got.
 #[inline]
-fn seed_matches(mt: &mut Mt19937, seed: u32, target: &[u8]) -> bool {
+fn prefix_match_len(mt: &mut Mt19937, seed: u32, target: &[u8]) -> usize {
     mt.init_genrand(seed);
+    let mut matched = 0;
     for &t in target {
-        if mt.limited_rand() != t as u32 {
-            return false;
+        if mt.limited_rand() == t as u32 {
+            matched += 1;
+        } else {
+            break;
         }
     }
-    true
+    matched
 }
 
-/// Scan up to `batch` seeds starting at `start`, stepping by `stride`.
-/// Returns the first seed whose output stream begins with `target`, or `None`.
+/// Scan up to `batch` seeds starting at `start`, stepping by `stride`. Returns a
+/// 3-element array `[found, seed, best_len]`:
+///
+/// - `found` is `1` if some seed fully reproduced `target`, else `0`.
+/// - `seed` is that winning seed (only meaningful when `found == 1`).
+/// - `best_len` is the longest `target` prefix any seed in this batch reproduced
+///   — i.e. how close this batch got — used for the live per-monkey display.
 ///
 /// Workers cover disjoint slices of the u32 seed space by choosing distinct
 /// `start` values and a shared `stride` (= worker count). `start` wraps modulo
 /// 2^32, matching the original site's behaviour.
 #[wasm_bindgen]
-pub fn search(target: &[u8], start: u32, stride: u32, batch: u32) -> Option<u32> {
+pub fn search(target: &[u8], start: u32, stride: u32, batch: u32) -> Vec<u32> {
     let mut mt = Mt19937::new();
     let mut seed = start;
+    let mut best_len = 0u32;
     for _ in 0..batch {
-        if seed_matches(&mut mt, seed, target) {
-            return Some(seed);
+        let matched = prefix_match_len(&mut mt, seed, target) as u32;
+        if matched as usize == target.len() {
+            return vec![1, seed, matched];
+        }
+        if matched > best_len {
+            best_len = matched;
         }
         seed = seed.wrapping_add(stride);
     }
-    None
+    vec![0, 0, best_len]
 }
 
 #[cfg(test)]
@@ -159,8 +174,8 @@ mod tests {
     #[test]
     fn search_finds_known_seed() {
         let target = [12u8, 15, 21]; // "mpv"
-        // Stride 1 from 0 must hit seed 0 immediately.
-        assert_eq!(search(&target, 0, 1, 10), Some(0));
+        // Stride 1 from 0 must hit seed 0 immediately: [found, seed, best_len].
+        assert_eq!(search(&target, 0, 1, 10), vec![1, 0, 3]);
     }
 
     /// A non-matching first byte abandons the seed (prefix semantics).
@@ -169,9 +184,20 @@ mod tests {
         let target = [0u8]; // "a"
         // seed 0's first letter is 'm' (12), not 'a' (0), so seed 0 is rejected;
         // some later seed produces 'a' first.
-        let found = search(&target, 0, 1, 1000).expect("a single-letter target must be findable");
-        let mut mt = Mt19937::new();
-        assert!(seed_matches(&mut mt, found, &target));
+        let r = search(&target, 0, 1, 1000);
+        assert_eq!(r[0], 1, "a single-letter target must be findable");
+        let found = r[1];
         assert_ne!(found, 0);
+        let mut mt = Mt19937::new();
+        assert_eq!(prefix_match_len(&mut mt, found, &target), 1);
+    }
+
+    /// `best_len` reports the closest (longest) prefix when there is no full match.
+    #[test]
+    fn search_reports_best_prefix() {
+        // Seed 0 -> "mpv…"; target "ma" matches only the leading 'm'.
+        let r = search(&[12, 0], 0, 1, 1); // scan seed 0 only
+        assert_eq!(r[0], 0, "not a full match");
+        assert_eq!(r[2], 1, "closest prefix is 'm' (length 1)");
     }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,9 +8,15 @@
   // `wrangler dev` / `wrangler deploy`. Output lands in public/pkg/ so it ships
   // as a static asset. watch_dir is the Rust source, so `wrangler dev` only
   // rebuilds the WASM when lib.rs changes (front-end edits hot-reload on their own).
+  //
+  // wasm-pack is installed on demand (mirroring cloudflare/rustwasm-worker-template's
+  // `cargo install -q worker-build`), so the Workers Builds image — which ships Rust
+  // but not wasm-pack — can build with no extra dashboard step. The `command -v`
+  // guard skips the install when wasm-pack is already present, so local `wrangler dev`
+  // doesn't re-check/upgrade it on every rebuild.
   // https://developers.cloudflare.com/workers/wrangler/custom-builds/
   "build": {
-    "command": "wasm-pack build --target web --out-dir public/pkg --release",
+    "command": "command -v wasm-pack >/dev/null 2>&1 || cargo install -q wasm-pack && wasm-pack build --target web --out-dir public/pkg --release",
     "watch_dir": "src"
   },
   "assets": {
@@ -22,4 +28,9 @@
   // https://developers.cloudflare.com/workers/configuration/previews/
   "workers_dev": true,
   "preview_urls": true
+  // The monkeynumber.xyz custom domain is attached to this Worker in the
+  // Cloudflare dashboard, intentionally NOT via a `routes` + `custom_domain`
+  // entry here: that entry breaks `wrangler dev`'s root-asset serving (the
+  // Preview tab / local dev would 404 on `/`). Per Cloudflare's docs, omitting
+  // `routes` leaves the dashboard-managed domain untouched on deploy.
 }


### PR DESCRIPTION
Single squashed commit. Carries the work that landed on `claude/fix-workers-deploy` *after* PR #3 was merged (the merge happened at `7a23ed5`, so these never reached `main`).

## Feature: one monkey per worker, each showing its closest match

The UI now renders **one monkey per running search worker**, and each shows **how close it has gotten** to the target word — the longest prefix it has reproduced — updating live. The winning monkey is highlighted green with the full word.

- `src/lib.rs` — `search` returns `[found, seed, best_len]`, tracking the longest target prefix any seed in the batch reproduced (new `prefix_match_len`). 5 unit tests pass.
- `public/monkey.worker.js` — relays the running best in each `progress` message; smaller batch (100k) so the closest updates often and visibly.
- `public/app.js` — builds one monkey card per worker; each shows the matched prefix (bold) + faded remainder; winner highlighted; idle monkey hides on submit.
- `public/index.html` / `public/style.css` — `#monkeys` grid + 120px `mini-monkey` sprite.

## Tooling

- **`.claude/launch.json`** — the Claude Code desktop **Preview tab** launches `npm run dev` (wrangler dev) on port 8787.
- **`wrangler.jsonc` build command installs wasm-pack on demand** — `command -v wasm-pack >/dev/null 2>&1 || cargo install -q wasm-pack && wasm-pack build …`, mirroring [`cloudflare/rustwasm-worker-template`](https://github.com/cloudflare/rustwasm-worker-template/blob/master/wrangler.toml#L10). The Workers Builds image ships Rust but not wasm-pack, so this lets it build with no extra dashboard step. The `command -v` guard skips the install when wasm-pack is already present, so local `wrangler dev` doesn't re-check/upgrade it on every rebuild (which would stall the Preview tab).
- **Custom domain** is dashboard-managed (no `routes` entry — that entry breaks `wrangler dev`'s root-asset serving).
- Documented why the release profile omits `strip` (it breaks wasm-pack's `wasm-opt`).
- README updated: the Workers Builds dashboard build command now installs **Rust only**.

## Verified

- `cargo test` → 5 passed.
- Build command tested: with wasm-pack present it builds and skips the install.
- Feature verified in the Preview tab: 12 monkeys for 12 cores; "pizza" → `srand(19030277)` (confirmed in Ruby); winner shows full "pizza" in green, others their best prefix; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)