### PR TITLE
Fix Workers Builds: self-installing npm run build

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm run dev        # builds the WASM, then runs `wrangler dev` at http://localho
 `npm run dev` rebuilds the WASM each time; to rebuild on its own:
 
 ```shell
-npm run build      # wasm-pack build --target web --out-dir public/pkg --release
+npm run build      # scripts/build.sh — installs the toolchain on demand, then wasm-pack build
 ```
 
 Run the Rust unit tests (MT19937 reference vectors, no WASM needed):
@@ -56,8 +56,16 @@ cargo test
 ## Deploy (Cloudflare Workers)
 
 Deployment runs through [Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/),
-connected to this Git repo. The build image doesn't ship Rust, so the **build
-command installs it** (via rustup) before `wrangler deploy` compiles the WASM.
+connected to this Git repo, using the **default commands** — no customization needed:
+
+- Build command: `npm run build`
+- Deploy command: `npx wrangler deploy`
+
+`npm run build` ([`scripts/build.sh`](scripts/build.sh)) is self-contained: the Workers
+Builds image ships Node but not Rust, so the script installs the Rust toolchain +
+wasm-pack on demand (a fast no-op locally, where they already exist), then compiles the
+WASM into `public/pkg/`. `npx wrangler deploy` then just uploads `public/` as static
+assets — the deploy step needs no toolchain.
 
 ### One-time setup
 
@@ -65,30 +73,9 @@ command installs it** (via rustup) before `wrangler deploy` compiles the WASM.
    *Connect to Git* → pick this repo. Set the production branch to `main`. (Create a
    **Worker**, not a Pages project — the wrangler-config "Skipping file" warning in the
    build log is expected and harmless for a Workers build.)
-2. **Build command** — installs Rust, which the image lacks. Each step must be on the
-   same line as the rest (the `. "$HOME/.cargo/env"` is required, or the next command
-   fails with `cargo: not found`):
-
-   ```shell
-   curl https://sh.rustup.rs -sSf | sh -s -- -y && . "$HOME/.cargo/env" && rustup target add wasm32-unknown-unknown
-   ```
-
-   No need to install wasm-pack here — the `build.command` hook in `wrangler.jsonc`
-   installs it on demand (`cargo install -q wasm-pack`) if it's missing.
-
-3. **Deploy command** — re-source cargo (separate shell), then deploy:
-
-   ```shell
-   . "$HOME/.cargo/env" && npx wrangler deploy
-   ```
-
-   `wrangler deploy` runs the `build.command` hook in `wrangler.jsonc`, which installs
-   wasm-pack (if absent), builds the WASM into `public/pkg/`, then uploads `public/` as
-   static assets.
-4. **Stop the old Pages deploy** — remove the `monkeynumber.xyz` custom domain from the
-   old Cloudflare Pages project and disable its automatic deployments (or delete it).
-5. **Move the domain to the Worker** — the `monkeynumber` Worker → Settings →
-   Domains & Routes → add `monkeynumber.xyz` as a custom domain.
+2. **Custom domain** — attach `monkeynumber.xyz` to the `monkeynumber` Worker
+   (Settings → Domains & Routes), and make sure the old Cloudflare Pages project is
+   deleted/disconnected so it doesn't fight for the domain.
 
 After that, every push to `main` redeploys automatically.
 
@@ -101,8 +88,6 @@ in the Workers Builds settings and every PR / non-`main` branch gets a
 
 ### Manual deploy (optional)
 
-With Rust installed locally (the build hook adds wasm-pack if it's missing):
-
 ```shell
-npm run deploy     # = wrangler deploy (builds the WASM via the wrangler build hook)
+npm run deploy     # = npm run build (toolchain installed on demand) && wrangler deploy
 ```

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "description": "Brute-force a Mersenne-Twister seed that reproduces a target word",
   "scripts": {
-    "build": "wasm-pack build --target web --out-dir public/pkg --release",
-    "dev": "wrangler dev",
-    "deploy": "wrangler deploy"
+    "build": "sh scripts/build.sh",
+    "dev": "npm run build && wrangler dev",
+    "deploy": "npm run build && wrangler deploy"
   },
   "devDependencies": {
     "wrangler": "^4.100.0"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+# Build the Rust seed-search to WASM (public/pkg/).
+#
+# This is self-contained so `npm run build` works in CI that ships Node but not
+# Rust — notably Cloudflare Workers Builds. Everything is guarded by a presence
+# check, so locally (where the toolchain already exists) it's a fast no-op apart
+# from the actual compile.
+set -e
+
+# 1. Rust toolchain (rustup installs cargo into ~/.cargo).
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "==> Installing Rust toolchain…"
+  curl https://sh.rustup.rs -sSf | sh -s -- -y
+fi
+[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+
+# 2. WASM target.
+rustup target add wasm32-unknown-unknown
+
+# 3. wasm-pack (compiled from source; only when missing).
+if ! command -v wasm-pack >/dev/null 2>&1; then
+  echo "==> Installing wasm-pack…"
+  cargo install -q wasm-pack
+fi
+
+# 4. Build.
+wasm-pack build --target web --out-dir public/pkg --release

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,21 +4,12 @@
   // https://developers.cloudflare.com/workers/static-assets/
   "name": "monkeynumber",
   "compatibility_date": "2026-06-14",
-  // Custom build: compile the Rust seed-search to WASM before every
-  // `wrangler dev` / `wrangler deploy`. Output lands in public/pkg/ so it ships
-  // as a static asset. watch_dir is the Rust source, so `wrangler dev` only
-  // rebuilds the WASM when lib.rs changes (front-end edits hot-reload on their own).
-  //
-  // wasm-pack is installed on demand (mirroring cloudflare/rustwasm-worker-template's
-  // `cargo install -q worker-build`), so the Workers Builds image — which ships Rust
-  // but not wasm-pack — can build with no extra dashboard step. The `command -v`
-  // guard skips the install when wasm-pack is already present, so local `wrangler dev`
-  // doesn't re-check/upgrade it on every rebuild.
-  // https://developers.cloudflare.com/workers/wrangler/custom-builds/
-  "build": {
-    "command": "command -v wasm-pack >/dev/null 2>&1 || cargo install -q wasm-pack && wasm-pack build --target web --out-dir public/pkg --release",
-    "watch_dir": "src"
-  },
+  // No `build` hook here: the WASM is built by `npm run build` (scripts/build.sh),
+  // which installs the Rust toolchain on demand so it works on the Workers Builds
+  // image (Node but no Rust). `wrangler deploy` then just uploads ./public — so the
+  // deploy step needs no toolchain. (Workers Builds runs the build command and the
+  // deploy command in separate shells, so a wrangler build hook couldn't see the
+  // toolchain the build command installed anyway.)
   "assets": {
     "directory": "./public"
   },


### PR DESCRIPTION
## Why the build kept failing

The latest Workers Builds log:
```
Detected the following tools from environment: bun@1.2.15, nodejs@22.16.0
Executing user build command: npm run build
> wasm-pack build --target web --out-dir public/pkg --release
sh: 1: wasm-pack: not found
```

Two compounding problems:
1. **The build image has no Rust at all** (only Node/bun) — so neither `wasm-pack` nor `cargo` exists.
2. The build command `npm run build` was just `wasm-pack build …` with nothing installing the toolchain.

The earlier "on-demand wasm-pack" hook couldn't fix this: `cargo install wasm-pack` needs cargo (also absent), and a `wrangler.jsonc` build hook runs in a *different shell* than the build command, so it can't see a toolchain the build command installed.

## Fix

Make `npm run build` self-contained via [`scripts/build.sh`](scripts/build.sh):
- installs the Rust toolchain (`rustup`) if `cargo` is missing,
- adds the `wasm32-unknown-unknown` target,
- installs `wasm-pack` if missing,
- runs `wasm-pack build`.

Every step is guarded by a presence check, so **locally it's a fast no-op** (only the compile runs).

Also **drop the `wrangler.jsonc` `build` hook** — the WASM is built by `npm run build`, and `npx wrangler deploy` now just uploads `public/` (no toolchain needed in the deploy step). `npm run dev` / `npm run deploy` build first.

## Result: zero dashboard changes needed

The **default** Workers Builds config now works as-is:
- Build command: `npm run build`
- Deploy command: `npx wrangler deploy`

No more rustup-in-the-dashboard-build-command. README simplified to match.

## Verified
- `npm run build` locally → skips the installs (toolchain present), compiles, 14.9 KB wasm.
- `cargo test` → 5 passed.
- Preview tab (`npm run dev` → `npm run build && wrangler dev`) → serves `/` (200) and the wasm as `application/wasm`.

The CI-only path (installing rustup + wasm-pack) can't be exercised locally, but it's standard `rustup`/`cargo install` — the build will take a few minutes longer on the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)